### PR TITLE
Added a return to the print_footer_scripts filter

### DIFF
--- a/comments-antispam.php
+++ b/comments-antispam.php
@@ -152,7 +152,7 @@ if (is_admin()) {
             );
             $js = str_replace(array_keys($x), $x, $js);
             echo($js);
-
+            return true;
         }
 
 


### PR DESCRIPTION
Hi! :slightly_smiling_face: 

The _print_footer_scripts_ filter hook is used in WordPress that way:

```php
/**
 * Filters whether to print the footer scripts.
 *
 * @since 2.8.0
 *
 * @param bool $print Whether to print the footer scripts. Default true.
 */
if ( apply_filters( 'print_footer_scripts', true ) ) {
	_print_scripts();
}
```

That means if a filter added to it doesn't return anything, it will consider it as a **false** return value and **not print any of the scripts** that have been added in the queue.

This small change fixes the problem.

If I can add a personal opinion on this, I think WordPress filters shouldn't be used to directly print data; its purpose is to change and return data only.

BR,

Gaelle